### PR TITLE
Prevent extra line break at start

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ fn main() {
             }
         }
     }
+    if &result[..1] == "\n" {
+        result.remove(0);
+    }
     set_clipboard(&result);
     println!("Clipboard updated");
 }


### PR DESCRIPTION
## Before
ls | ./coppy.exe
```

build/
coppy.d
coppy.exe*
coppy.pdb
deps/
examples/
incremental/
```

## After
$ ls | ./coppy.exe
```
build/
coppy.d
coppy.exe*
coppy.pdb
deps/
examples/
incremental/
```